### PR TITLE
New button to add event to Google Calendar

### DIFF
--- a/app/[event]/calendar-download.tsx
+++ b/app/[event]/calendar-download.tsx
@@ -1,0 +1,45 @@
+import { Button, Tooltip } from "@mui/material";
+import InsertInvitationIcon from '@mui/icons-material/InsertInvitation';
+import { Event } from "../types"
+
+type CalendarDownloadProps = {
+    event: Event,
+    tooltipOpen?: boolean,
+    onOpen?: () => void,
+    onClose?: () => void,
+}
+
+export default function CalendarDownload({ event, tooltipOpen, onOpen, onClose }: CalendarDownloadProps) {
+    const { title, location } = event;
+    // Add the event url to the description
+    const description = event.description ? event.description + `\n\nhttps://rsvp.chase.link/${event.id}` : `https://rsvp.chase.link/${event.id}`;
+    // Google Calendar requires the date to be in a specific format
+    // YYYYMMDDTHHmmSSZ/YYYYMMDDTHHmmSSZ
+    const date = event.date.toISOString().replace(/-|:|\.\d+/g, '');
+
+    // Google Calendar add event url reference: https://github.com/InteractionDesignFoundation/add-event-to-calendar-docs/blob/main/services/google.md#parameters
+    const gcalAddEventUrl = new URL('https://www.google.com/calendar/render');
+    gcalAddEventUrl.searchParams.append('action', 'TEMPLATE');
+    gcalAddEventUrl.searchParams.append('text', title);
+    gcalAddEventUrl.searchParams.append('dates', `${date}/${date}`);
+    gcalAddEventUrl.searchParams.append('details', description);
+    gcalAddEventUrl.searchParams.append('location', location);
+
+    return (
+        <Tooltip 
+            title="Add to Google Calendar" 
+            arrow 
+            open={tooltipOpen} 
+            onOpen={onOpen} 
+            onClose={onClose}
+        >
+            <Button
+                href={gcalAddEventUrl.toString()}
+                target="_blank"
+                rel="noreferrer"
+            >
+                <InsertInvitationIcon />
+            </Button>
+        </Tooltip>
+    )
+}

--- a/app/[event]/event.tsx
+++ b/app/[event]/event.tsx
@@ -15,6 +15,7 @@ import { getAttendeeCount } from "../_utils/helpers";
 import EventForm from "../_components/event-form";
 import ModalContent from "../_components/modal-content";
 import EventMenu from "./event-menu";
+import CalendarDownload from "./calendar-download";
 
 type EventDetailProps = {
     icon: React.ReactNode,
@@ -139,6 +140,7 @@ export default function EventPage({ event }: EventPageProps) {
     const [showEditEvent, setShowEditEvent] = useState(false);
     const [showDeleteEvent, setShowDeleteEvent] = useState(false);
     const [rsvpDefaultValues, setRsvpDefaultValues] = useState<Partial<Attendee> | null>(null);
+    const [calendarTooltipOpen, setCalendarTooltipOpen] = useState(false);
     const deleteEventPasswordRef = useRef<HTMLInputElement>(null);
     const { title, id, date, description, location, attendees, changelog } = event;
     const supplies = getSuppliesFromAttendees(attendees);
@@ -226,6 +228,12 @@ export default function EventPage({ event }: EventPageProps) {
 
         router.refresh();
 
+        // Wait half a second, then show the calendar tooltip
+        // to let the user know they can download the event
+        setTimeout(() => setCalendarTooltipOpen(true), 500);
+        // Wait 8 seconds, then hide the calendar tooltip
+        setTimeout(() => setCalendarTooltipOpen(false), 8000);
+
         return Promise.resolve();
     }
 
@@ -308,7 +316,7 @@ export default function EventPage({ event }: EventPageProps) {
                         })
                     }
                 />
-                <Typography variant="body1" style={{whiteSpace: 'pre-wrap'}}>{description}</Typography>
+                <Typography variant="body1" style={{ whiteSpace: 'pre-wrap' }}>{description}</Typography>
             </div>
 
             <div style={styles.buttonRow}>
@@ -321,10 +329,19 @@ export default function EventPage({ event }: EventPageProps) {
                     RSVP
                 </Button>
 
-                <EventMenu
-                    onEdit={() => setShowEditEvent(true)}
-                    onDelete={() => setShowDeleteEvent(true)}
-                />
+                <div style={styles.iconButtons}>
+                    <CalendarDownload
+                        event={event}
+                        tooltipOpen={calendarTooltipOpen}
+                        onOpen={() => setCalendarTooltipOpen(true)}
+                        onClose={() => setCalendarTooltipOpen(false)}
+                    />
+
+                    <EventMenu
+                        onEdit={() => setShowEditEvent(true)}
+                        onDelete={() => setShowDeleteEvent(true)}
+                    />
+                </div>
             </div>
 
             <Attendees
@@ -375,8 +392,8 @@ export default function EventPage({ event }: EventPageProps) {
                     />
                 </ModalContent>
             </Modal>
-            <Dialog 
-                open={showDeleteEvent} 
+            <Dialog
+                open={showDeleteEvent}
                 onClose={() => setShowDeleteEvent(false)}
                 fullWidth
             >
@@ -391,12 +408,12 @@ export default function EventPage({ event }: EventPageProps) {
                     />
                 </DialogContent>
                 <DialogActions>
-                    <Button 
+                    <Button
                         onClick={() => setShowDeleteEvent(false)}
                     >
                         Cancel
                     </Button>
-                    <Button 
+                    <Button
                         onClick={async () => {
                             await handleDeleteEvent()
                             setShowDeleteEvent(false)
@@ -429,5 +446,8 @@ const styles = {
         justifyContent: 'space-between',
         alignItems: 'center',
         margin: '2rem 0',
+    },
+    iconButtons: {
+        display: 'flex',
     },
 };


### PR DESCRIPTION
This adds a new button to add an event to google calendar. After RSVP-ing to an event, the tooltip for the button will briefly show.